### PR TITLE
Added "no-transform" to Cache-Control header

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,7 +13,7 @@ export const plugin: FastifyPluginAsync<SsePluginOptions> =
           outputStream.write(serializeSSEEvent({retry: options.retryDelay || 3000}));
           this.type("text/event-stream")
             .header("Connection", "keep-alive")
-            .header("Cache-Control", "no-cache");
+            .header("Cache-Control", "no-cache,no-transform");
           toStream(transformAsyncIterable(source)).pipe(outputStream);
         });
     };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,7 +13,8 @@ export const plugin: FastifyPluginAsync<SsePluginOptions> =
           outputStream.write(serializeSSEEvent({retry: options.retryDelay || 3000}));
           this.type("text/event-stream")
             .header("Connection", "keep-alive")
-            .header("Cache-Control", "no-cache,no-transform");
+            .header("Cache-Control", "no-cache,no-transform")
+            .header("x-no-compression", true);
           toStream(transformAsyncIterable(source)).pipe(outputStream);
         });
     };


### PR DESCRIPTION
Some proxies buffers SSE events to compress the stream, delaying the browser event reception. The `no-transform` `Cache-Control` directive forbids this bad behavior. More info at:

https://github.com/facebook/create-react-app/issues/1633
https://github.com/vercel/next.js/issues/9965#issuecomment-584319868