### PR TITLE
Default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export const FastifySSEPlugin = fastifyPlugin(plugin, {
   fastify: "3.x",
 });
 
+export default FastifySSEPlugin
+
 declare module "fastify" {
 
   interface EventMessage {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export const FastifySSEPlugin = fastifyPlugin(plugin, {
   fastify: "3.x",
 });
 
-export default FastifySSEPlugin
+export default FastifySSEPlugin;
 
 declare module "fastify" {
 


### PR DESCRIPTION
Currently, I can only import this plugin with the exact name `FastifySSEPlugin`:

```js
const { FastifySSEPlugin } = require('fastify-sse-v2')
```

Renaming the import is also an option, but unnecessarily verbose. It would be nice if the plugin was exported via the default export in addition to a named export. The other Fastify plugins I've seen so far all do this. If you accept this pull request, the plugin could also be imported as:

```js
const sse = require('fastify-sse-v2')
```

I've run the test and lint commands to verify that nothing breaks due to this change.