### PR TITLE
feat: Added option to send comment in Event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,11 @@ declare module "fastify" {
      * Update client reconnect interval (how long will client wait before trying to reconnect).
      */
     retry?: number;
+
+    /**
+     * Message comment
+     */
+    comment?: string;
   }
 
   interface FastifyReply {
@@ -59,4 +64,9 @@ export interface EventMessage {
    * Update client reconnect interval (how long will client wait before trying to reconnect).
    */
   retry?: number;
+
+  /**
+   * Message comment
+   */
+  comment?: string;
 }

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -23,6 +23,9 @@ export function serializeSSEEvent(chunk: EventMessage): string {
   if (chunk.retry) {
     payload += `retry: ${chunk.retry}\n`;
   }
+  if (chunk.comment) {
+    payload += `:${chunk.comment}\n`;
+  }
   if (!payload) {
     return "";
   }


### PR DESCRIPTION
Hello,
first of all thanks for library. I am using this lib to create simple push server to which clients can connect and will remain connected to receive message continuously. There may be one problem - underlying connection can get closed on any path to the client. I resolved this problem with periodically sending comment messages which do not fire handlers on client-side and keep connection alive.

This is what this PR helps with - allows users to send comments in event messages. According to [specification](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format) line is treated as comment when it starts with `:` symbol.